### PR TITLE
fix(model): Remove north from Model properties

### DIFF
--- a/dragonfly_schema/energy/properties.py
+++ b/dragonfly_schema/energy/properties.py
@@ -9,7 +9,6 @@ from honeybee_schema.energy.constructionset import ConstructionSetAbridged, \
 from honeybee_schema.energy.programtype import ProgramTypeAbridged, ProgramType
 from honeybee_schema.energy.hvac import IdealAirSystemAbridged
 
-from honeybee_schema.energy.properties import TerrianTypes
 from honeybee_schema.energy.construction import OpaqueConstructionAbridged, \
     WindowConstructionAbridged, ShadeConstruction, AirBoundaryConstructionAbridged, \
     OpaqueConstruction, WindowConstruction, AirBoundaryConstruction
@@ -104,19 +103,13 @@ class ContextShadeEnergyPropertiesAbridged(NoExtraBaseModel):
         max_length=100,
         description='Name of a schedule to set the transmittance of the ContextShade, '
             'which can vary throughout the simulation. If None, the ContextShade will '
-            'be completely opauqe.'
+            'be completely opaque.'
     )
 
 
 class ModelEnergyProperties(NoExtraBaseModel):
 
     type: constr(regex='^ModelEnergyProperties$') = 'ModelEnergyProperties'
-
-    terrain_type: TerrianTypes = Field(
-        default=TerrianTypes.city,
-        description='Text for the terrain in which the model sits. This is used '
-            'to determine the wind profile over the height of the buildings.'
-    )
 
     global_construction_set: str = Field(
         default=None,

--- a/dragonfly_schema/model.py
+++ b/dragonfly_schema/model.py
@@ -1,6 +1,7 @@
 """Model schema and the 3 geometry objects that define it."""
-from pydantic import BaseModel, Field, root_validator, constr, conlist
+from pydantic import BaseModel, Field, validator, root_validator, constr, conlist
 from typing import List, Union
+from enum import Enum
 
 from honeybee_schema._base import IDdBaseModel
 from honeybee_schema.model import Face3D, Units
@@ -243,13 +244,6 @@ class Model(IDdBaseModel):
     context_shades: List[ContextShade] = Field(
         None,
         description='A list of ContextShades in the model.'
-    )
-
-    north_angle: float = Field(
-        default=0,
-        ge=0,
-        lt=360,
-        description='The clockwise north direction in degrees.'
     )
 
     units: Units = Field(

--- a/samples/model_complete_simple.json
+++ b/samples/model_complete_simple.json
@@ -6,7 +6,6 @@
         "type": "ModelProperties",
         "energy": {
             "type": "ModelEnergyProperties",
-            "terrain_type": "City",
             "construction_sets": [
                 {
                     "type": "ConstructionSetAbridged",
@@ -91,33 +90,11 @@
             "constructions": [
                 {
                     "type": "OpaqueConstructionAbridged",
-                    "identifier": "Generic Ground Slab",
+                    "identifier": "Generic Interior Floor",
                     "layers": [
-                        "Generic 50mm Insulation",
-                        "Generic HW Concrete"
-                    ]
-                },
-                {
-                    "type": "WindowConstructionAbridged",
-                    "identifier": "Generic Single Pane",
-                    "layers": [
-                        "Generic Clear Glass"
-                    ]
-                },
-                {
-                    "type": "ShadeConstruction",
-                    "identifier": "Generic Shade",
-                    "solar_reflectance": 0.35,
-                    "visible_reflectance": 0.35,
-                    "is_specular": false
-                },
-                {
-                    "type": "WindowConstructionAbridged",
-                    "identifier": "Generic Double Pane",
-                    "layers": [
-                        "Generic Low-e Glass",
-                        "Generic Window Air Gap",
-                        "Generic Clear Glass"
+                        "Generic Acoustic Tile",
+                        "Generic Ceiling Air Gap",
+                        "Generic LW Concrete"
                     ]
                 },
                 {
@@ -126,6 +103,43 @@
                     "solar_reflectance": 0.5,
                     "visible_reflectance": 0.5,
                     "is_specular": true
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Underground Roof",
+                    "layers": [
+                        "Generic 50mm Insulation",
+                        "Generic HW Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Interior Ceiling",
+                    "layers": [
+                        "Generic LW Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Interior Wall",
+                    "layers": [
+                        "Generic Gypsum Board",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Attic Roof Construction",
+                    "layers": [
+                        "Generic Roof Membrane",
+                        "PolyIso",
+                        "Generic 25mm Wood"
+                    ]
                 },
                 {
                     "type": "OpaqueConstructionAbridged",
@@ -140,37 +154,45 @@
                 },
                 {
                     "type": "OpaqueConstructionAbridged",
-                    "identifier": "Generic Interior Door",
+                    "identifier": "Generic Ground Slab",
                     "layers": [
+                        "Generic 50mm Insulation",
+                        "Generic HW Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Attic Floor Construction",
+                    "layers": [
+                        "Generic 25mm Wood",
+                        "Generic 50mm Insulation",
                         "Generic 25mm Wood"
                     ]
                 },
                 {
-                    "type": "OpaqueConstructionAbridged",
-                    "identifier": "Generic Underground Wall",
-                    "layers": [
-                        "Generic 50mm Insulation",
-                        "Generic HW Concrete",
-                        "Generic Wall Air Gap",
-                        "Generic Gypsum Board"
-                    ]
+                    "type": "ShadeConstruction",
+                    "identifier": "Generic Shade",
+                    "solar_reflectance": 0.35,
+                    "visible_reflectance": 0.35,
+                    "is_specular": false
                 },
                 {
                     "type": "OpaqueConstructionAbridged",
-                    "identifier": "Generic Interior Wall",
+                    "identifier": "Generic Exposed Floor",
                     "layers": [
-                        "Generic Gypsum Board",
-                        "Generic Wall Air Gap",
-                        "Generic Gypsum Board"
-                    ]
-                },
-                {
-                    "type": "OpaqueConstructionAbridged",
-                    "identifier": "Generic Interior Floor",
-                    "layers": [
-                        "Generic Acoustic Tile",
+                        "Generic Painted Metal",
                         "Generic Ceiling Air Gap",
+                        "Generic 50mm Insulation",
                         "Generic LW Concrete"
+                    ]
+                },
+                {
+                    "type": "WindowConstructionAbridged",
+                    "identifier": "Generic Double Pane",
+                    "layers": [
+                        "Generic Low-e Glass",
+                        "Generic Window Air Gap",
+                        "Generic Clear Glass"
                     ]
                 },
                 {
@@ -185,6 +207,22 @@
                     ]
                 },
                 {
+                    "type": "AirBoundaryConstructionAbridged",
+                    "identifier": "Generic Air Boundary",
+                    "air_mixing_per_area": 0.1,
+                    "air_mixing_schedule": "Always On"
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Underground Wall",
+                    "layers": [
+                        "Generic 50mm Insulation",
+                        "Generic HW Concrete",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                },
+                {
                     "type": "OpaqueConstructionAbridged",
                     "identifier": "Generic Exterior Door",
                     "layers": [
@@ -195,65 +233,86 @@
                 },
                 {
                     "type": "OpaqueConstructionAbridged",
-                    "identifier": "Generic Interior Ceiling",
+                    "identifier": "Generic Interior Door",
                     "layers": [
-                        "Generic LW Concrete",
-                        "Generic Ceiling Air Gap",
-                        "Generic Acoustic Tile"
-                    ]
-                },
-                {
-                    "type": "OpaqueConstructionAbridged",
-                    "identifier": "Generic Underground Roof",
-                    "layers": [
-                        "Generic 50mm Insulation",
-                        "Generic HW Concrete",
-                        "Generic Ceiling Air Gap",
-                        "Generic Acoustic Tile"
-                    ]
-                },
-                {
-                    "type": "AirBoundaryConstructionAbridged",
-                    "identifier": "Generic Air Boundary",
-                    "air_mixing_per_area": 0.1,
-                    "air_mixing_schedule": "Always On"
-                },
-                {
-                    "type": "OpaqueConstructionAbridged",
-                    "identifier": "Generic Exposed Floor",
-                    "layers": [
-                        "Generic Painted Metal",
-                        "Generic Ceiling Air Gap",
-                        "Generic 50mm Insulation",
-                        "Generic LW Concrete"
-                    ]
-                },
-                {
-                    "type": "OpaqueConstructionAbridged",
-                    "identifier": "Attic Roof Construction",
-                    "layers": [
-                        "Generic Roof Membrane",
-                        "PolyIso",
                         "Generic 25mm Wood"
                     ]
                 },
                 {
-                    "type": "OpaqueConstructionAbridged",
-                    "identifier": "Attic Floor Construction",
+                    "type": "WindowConstructionAbridged",
+                    "identifier": "Generic Single Pane",
                     "layers": [
-                        "Generic 25mm Wood",
-                        "Generic 50mm Insulation",
-                        "Generic 25mm Wood"
+                        "Generic Clear Glass"
                     ]
                 }
             ],
             "materials": [
                 {
                     "type": "EnergyMaterial",
-                    "identifier": "Generic Ceiling Air Gap",
+                    "identifier": "PolyIso",
+                    "roughness": "MediumRough",
+                    "thickness": 0.2,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 25mm Wood",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0254,
+                    "conductivity": 0.15,
+                    "density": 608.0,
+                    "specific_heat": 1630.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 50mm Insulation",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Gypsum Board",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0127,
+                    "conductivity": 0.16,
+                    "density": 800.0,
+                    "specific_heat": 1090.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic LW Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.53,
+                    "density": 1280.0,
+                    "specific_heat": 840.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Wall Air Gap",
                     "roughness": "Smooth",
                     "thickness": 0.1,
-                    "conductivity": 0.556,
+                    "conductivity": 0.667,
                     "density": 1.28,
                     "specific_heat": 1000.0,
                     "thermal_absorptance": 0.9,
@@ -273,6 +332,84 @@
                     "visible_absorptance": 0.5
                 },
                 {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Acoustic Tile",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.02,
+                    "conductivity": 0.06,
+                    "density": 368.0,
+                    "specific_heat": 590.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.2,
+                    "visible_absorptance": 0.2
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Brick",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.9,
+                    "density": 1920.0,
+                    "specific_heat": 790.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.65,
+                    "visible_absorptance": 0.65
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 25mm Insulation",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Ceiling Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.556,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic HW Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.2,
+                    "conductivity": 1.95,
+                    "density": 2240.0,
+                    "specific_heat": 900.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyWindowMaterialGas",
+                    "identifier": "Generic Window Air Gap",
+                    "thickness": 0.0127,
+                    "gas_type": "Air"
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Roof Membrane",
+                    "roughness": "MediumRough",
+                    "thickness": 0.01,
+                    "conductivity": 0.16,
+                    "density": 1120.0,
+                    "specific_heat": 1460.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.65,
+                    "visible_absorptance": 0.65
+                },
+                {
                     "type": "EnergyWindowMaterialGlazing",
                     "identifier": "Generic Low-e Glass",
                     "thickness": 0.006,
@@ -290,24 +427,6 @@
                     "solar_diffusing": false
                 },
                 {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic 25mm Insulation",
-                    "roughness": "MediumRough",
-                    "thickness": 0.05,
-                    "conductivity": 0.03,
-                    "density": 43.0,
-                    "specific_heat": 1210.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
-                },
-                {
-                    "type": "EnergyWindowMaterialGas",
-                    "identifier": "Generic Window Air Gap",
-                    "thickness": 0.0127,
-                    "gas_type": "Air"
-                },
-                {
                     "type": "EnergyWindowMaterialGlazing",
                     "identifier": "Generic Clear Glass",
                     "thickness": 0.006,
@@ -323,126 +442,6 @@
                     "conductivity": 1.0,
                     "dirt_correction": 1.0,
                     "solar_diffusing": false
-                },
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic Brick",
-                    "roughness": "MediumRough",
-                    "thickness": 0.1,
-                    "conductivity": 0.9,
-                    "density": 1920.0,
-                    "specific_heat": 790.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.65,
-                    "visible_absorptance": 0.65
-                },
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic Gypsum Board",
-                    "roughness": "MediumSmooth",
-                    "thickness": 0.0127,
-                    "conductivity": 0.16,
-                    "density": 800.0,
-                    "specific_heat": 1090.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.5,
-                    "visible_absorptance": 0.5
-                },
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "PolyIso",
-                    "roughness": "MediumRough",
-                    "thickness": 0.2,
-                    "conductivity": 0.03,
-                    "density": 43.0,
-                    "specific_heat": 1210.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
-                },
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic LW Concrete",
-                    "roughness": "MediumRough",
-                    "thickness": 0.1,
-                    "conductivity": 0.53,
-                    "density": 1280.0,
-                    "specific_heat": 840.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.8,
-                    "visible_absorptance": 0.8
-                },
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic HW Concrete",
-                    "roughness": "MediumRough",
-                    "thickness": 0.2,
-                    "conductivity": 1.95,
-                    "density": 2240.0,
-                    "specific_heat": 900.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.8,
-                    "visible_absorptance": 0.8
-                },
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic Acoustic Tile",
-                    "roughness": "MediumSmooth",
-                    "thickness": 0.02,
-                    "conductivity": 0.06,
-                    "density": 368.0,
-                    "specific_heat": 590.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.2,
-                    "visible_absorptance": 0.2
-                },
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic Roof Membrane",
-                    "roughness": "MediumRough",
-                    "thickness": 0.01,
-                    "conductivity": 0.16,
-                    "density": 1120.0,
-                    "specific_heat": 1460.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.65,
-                    "visible_absorptance": 0.65
-                },
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic Wall Air Gap",
-                    "roughness": "Smooth",
-                    "thickness": 0.1,
-                    "conductivity": 0.667,
-                    "density": 1.28,
-                    "specific_heat": 1000.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
-                },
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic 50mm Insulation",
-                    "roughness": "MediumRough",
-                    "thickness": 0.05,
-                    "conductivity": 0.03,
-                    "density": 43.0,
-                    "specific_heat": 1210.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.7,
-                    "visible_absorptance": 0.7
-                },
-                {
-                    "type": "EnergyMaterial",
-                    "identifier": "Generic 25mm Wood",
-                    "roughness": "MediumSmooth",
-                    "thickness": 0.0254,
-                    "conductivity": 0.15,
-                    "density": 608.0,
-                    "specific_heat": 1630.0,
-                    "thermal_absorptance": 0.9,
-                    "solar_absorptance": 0.5,
-                    "visible_absorptance": 0.5
                 }
             ],
             "hvacs": [
@@ -546,6 +545,19 @@
             "program_types": [
                 {
                     "type": "ProgramTypeAbridged",
+                    "identifier": "Attic Space",
+                    "lighting": {
+                        "type": "LightingAbridged",
+                        "identifier": "Attic Lighting",
+                        "watts_per_area": 3.0,
+                        "return_air_fraction": 0.0,
+                        "radiant_fraction": 0.32,
+                        "visible_fraction": 0.25,
+                        "schedule": "Always Dim"
+                    }
+                },
+                {
+                    "type": "ProgramTypeAbridged",
                     "identifier": "Generic Office Program",
                     "people": {
                         "type": "PeopleAbridged",
@@ -594,19 +606,6 @@
                         "heating_schedule": "Generic Office Heating",
                         "cooling_schedule": "Generic Office Cooling"
                     }
-                },
-                {
-                    "type": "ProgramTypeAbridged",
-                    "identifier": "Attic Space",
-                    "lighting": {
-                        "type": "LightingAbridged",
-                        "identifier": "Attic Lighting",
-                        "watts_per_area": 3.0,
-                        "return_air_fraction": 0.0,
-                        "radiant_fraction": 0.32,
-                        "visible_fraction": 0.25,
-                        "schedule": "Always Dim"
-                    }
                 }
             ],
             "schedules": [
@@ -653,368 +652,6 @@
                     ],
                     "default_day_schedule": "Always On_Day Schedule",
                     "schedule_type_limit": "Fractional"
-                },
-                {
-                    "type": "ScheduleRulesetAbridged",
-                    "identifier": "Generic Office Cooling",
-                    "day_schedules": [
-                        {
-                            "type": "ScheduleDay",
-                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
-                            "values": [
-                                26.7
-                            ],
-                            "times": [
-                                [
-                                    0,
-                                    0
-                                ]
-                            ],
-                            "interpolate": false
-                        },
-                        {
-                            "type": "ScheduleDay",
-                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_SmrDsn",
-                            "values": [
-                                26.7,
-                                25.7,
-                                25.0,
-                                24.0,
-                                26.7
-                            ],
-                            "times": [
-                                [
-                                    0,
-                                    0
-                                ],
-                                [
-                                    5,
-                                    0
-                                ],
-                                [
-                                    6,
-                                    0
-                                ],
-                                [
-                                    7,
-                                    0
-                                ],
-                                [
-                                    22,
-                                    0
-                                ]
-                            ],
-                            "interpolate": false
-                        },
-                        {
-                            "type": "ScheduleDay",
-                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default_WntrDsn",
-                            "values": [
-                                26.7
-                            ],
-                            "times": [
-                                [
-                                    0,
-                                    0
-                                ]
-                            ],
-                            "interpolate": false
-                        },
-                        {
-                            "type": "ScheduleDay",
-                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Wkdy",
-                            "values": [
-                                26.7,
-                                25.6,
-                                25.0,
-                                24.0,
-                                26.7
-                            ],
-                            "times": [
-                                [
-                                    0,
-                                    0
-                                ],
-                                [
-                                    5,
-                                    0
-                                ],
-                                [
-                                    6,
-                                    0
-                                ],
-                                [
-                                    7,
-                                    0
-                                ],
-                                [
-                                    22,
-                                    0
-                                ]
-                            ],
-                            "interpolate": false
-                        },
-                        {
-                            "type": "ScheduleDay",
-                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Sat",
-                            "values": [
-                                26.7,
-                                25.7,
-                                25.0,
-                                24.0,
-                                26.7
-                            ],
-                            "times": [
-                                [
-                                    0,
-                                    0
-                                ],
-                                [
-                                    5,
-                                    0
-                                ],
-                                [
-                                    6,
-                                    0
-                                ],
-                                [
-                                    7,
-                                    0
-                                ],
-                                [
-                                    17,
-                                    0
-                                ]
-                            ],
-                            "interpolate": false
-                        }
-                    ],
-                    "default_day_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
-                    "schedule_rules": [
-                        {
-                            "type": "ScheduleRuleAbridged",
-                            "schedule_day": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Wkdy",
-                            "apply_sunday": false,
-                            "apply_monday": true,
-                            "apply_tuesday": true,
-                            "apply_wednesday": true,
-                            "apply_thursday": true,
-                            "apply_friday": true,
-                            "apply_saturday": false,
-                            "start_date": [
-                                1,
-                                1
-                            ],
-                            "end_date": [
-                                12,
-                                31
-                            ]
-                        },
-                        {
-                            "type": "ScheduleRuleAbridged",
-                            "schedule_day": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Sat",
-                            "apply_sunday": false,
-                            "apply_monday": false,
-                            "apply_tuesday": false,
-                            "apply_wednesday": false,
-                            "apply_thursday": false,
-                            "apply_friday": false,
-                            "apply_saturday": true,
-                            "start_date": [
-                                1,
-                                1
-                            ],
-                            "end_date": [
-                                12,
-                                31
-                            ]
-                        }
-                    ],
-                    "holiday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
-                    "summer_designday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_SmrDsn",
-                    "winter_designday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default_WntrDsn",
-                    "schedule_type_limit": "Temperature"
-                },
-                {
-                    "type": "ScheduleRulesetAbridged",
-                    "identifier": "Generic Office Heating",
-                    "day_schedules": [
-                        {
-                            "type": "ScheduleDay",
-                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
-                            "values": [
-                                15.6
-                            ],
-                            "times": [
-                                [
-                                    0,
-                                    0
-                                ]
-                            ],
-                            "interpolate": false
-                        },
-                        {
-                            "type": "ScheduleDay",
-                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default_SmrDsn",
-                            "values": [
-                                15.6
-                            ],
-                            "times": [
-                                [
-                                    0,
-                                    0
-                                ]
-                            ],
-                            "interpolate": false
-                        },
-                        {
-                            "type": "ScheduleDay",
-                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_WntrDsn",
-                            "values": [
-                                15.6,
-                                17.6,
-                                19.6,
-                                21.0,
-                                15.6
-                            ],
-                            "times": [
-                                [
-                                    0,
-                                    0
-                                ],
-                                [
-                                    5,
-                                    0
-                                ],
-                                [
-                                    6,
-                                    0
-                                ],
-                                [
-                                    7,
-                                    0
-                                ],
-                                [
-                                    22,
-                                    0
-                                ]
-                            ],
-                            "interpolate": false
-                        },
-                        {
-                            "type": "ScheduleDay",
-                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Wkdy",
-                            "values": [
-                                15.6,
-                                17.8,
-                                20.0,
-                                21.0,
-                                15.6
-                            ],
-                            "times": [
-                                [
-                                    0,
-                                    0
-                                ],
-                                [
-                                    5,
-                                    0
-                                ],
-                                [
-                                    6,
-                                    0
-                                ],
-                                [
-                                    7,
-                                    0
-                                ],
-                                [
-                                    22,
-                                    0
-                                ]
-                            ],
-                            "interpolate": false
-                        },
-                        {
-                            "type": "ScheduleDay",
-                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Sat",
-                            "values": [
-                                15.6,
-                                17.8,
-                                20.0,
-                                21.0,
-                                15.6
-                            ],
-                            "times": [
-                                [
-                                    0,
-                                    0
-                                ],
-                                [
-                                    5,
-                                    0
-                                ],
-                                [
-                                    6,
-                                    0
-                                ],
-                                [
-                                    7,
-                                    0
-                                ],
-                                [
-                                    17,
-                                    0
-                                ]
-                            ],
-                            "interpolate": false
-                        }
-                    ],
-                    "default_day_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
-                    "schedule_rules": [
-                        {
-                            "type": "ScheduleRuleAbridged",
-                            "schedule_day": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Wkdy",
-                            "apply_sunday": false,
-                            "apply_monday": true,
-                            "apply_tuesday": true,
-                            "apply_wednesday": true,
-                            "apply_thursday": true,
-                            "apply_friday": true,
-                            "apply_saturday": false,
-                            "start_date": [
-                                1,
-                                1
-                            ],
-                            "end_date": [
-                                12,
-                                31
-                            ]
-                        },
-                        {
-                            "type": "ScheduleRuleAbridged",
-                            "schedule_day": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Sat",
-                            "apply_sunday": false,
-                            "apply_monday": false,
-                            "apply_tuesday": false,
-                            "apply_wednesday": false,
-                            "apply_thursday": false,
-                            "apply_friday": false,
-                            "apply_saturday": true,
-                            "start_date": [
-                                1,
-                                1
-                            ],
-                            "end_date": [
-                                12,
-                                31
-                            ]
-                        }
-                    ],
-                    "holiday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
-                    "summer_designday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default_SmrDsn",
-                    "winter_designday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_WntrDsn",
-                    "schedule_type_limit": "Temperature"
                 },
                 {
                     "type": "ScheduleRulesetAbridged",
@@ -1201,15 +838,377 @@
                 },
                 {
                     "type": "ScheduleRulesetAbridged",
-                    "identifier": "Generic Office Lighting",
+                    "identifier": "Generic Office Heating",
                     "day_schedules": [
                         {
                             "type": "ScheduleDay",
-                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Sun",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
                             "values": [
-                                0.05,
-                                0.04311628,
-                                0.05
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default_SmrDsn",
+                            "values": [
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_WntrDsn",
+                            "values": [
+                                15.6,
+                                17.6,
+                                19.6,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "values": [
+                                15.6,
+                                17.8,
+                                20.0,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Sat",
+                            "values": [
+                                15.6,
+                                17.8,
+                                20.0,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                    "summer_designday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_WntrDsn",
+                    "schedule_type_limit": "Temperature"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Cooling",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                            "values": [
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_SmrDsn",
+                            "values": [
+                                26.7,
+                                25.7,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default_WntrDsn",
+                            "values": [
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "values": [
+                                26.7,
+                                25.6,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Sat",
+                            "values": [
+                                26.7,
+                                25.7,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                    "summer_designday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default_WntrDsn",
+                    "schedule_type_limit": "Temperature"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Equipment",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Sun",
+                            "values": [
+                                0.2307553806,
+                                0.288107175,
+                                0.2307553806
                             ],
                             "times": [
                                 [
@@ -1229,7 +1228,7 @@
                         },
                         {
                             "type": "ScheduleDay",
-                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_SmrDsn",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_SmrDsn",
                             "values": [
                                 1.0
                             ],
@@ -1243,7 +1242,7 @@
                         },
                         {
                             "type": "ScheduleDay",
-                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_WntrDsn",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_WntrDsn",
                             "values": [
                                 0.0
                             ],
@@ -1257,14 +1256,14 @@
                         },
                         {
                             "type": "ScheduleDay",
-                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
                             "values": [
-                                0.05,
-                                0.08623256,
-                                0.25869768,
-                                0.12934884,
-                                0.04311628,
-                                0.05
+                                0.2307553806,
+                                0.381234796,
+                                0.476543495,
+                                0.3335804465,
+                                0.285926097,
+                                0.2307553806
                             ],
                             "times": [
                                 [
@@ -1296,18 +1295,15 @@
                         },
                         {
                             "type": "ScheduleDay",
-                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Wkdy",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Wkdy",
                             "values": [
-                                0.05,
-                                0.1,
-                                0.08623256,
-                                0.25869768,
-                                0.77609304,
-                                0.4311628,
-                                0.25869768,
-                                0.17246512,
-                                0.08623256,
-                                0.04311628
+                                0.3076738408,
+                                0.381234796,
+                                0.857778291,
+                                0.762469592,
+                                0.857778291,
+                                0.476543495,
+                                0.381234796
                             ],
                             "times": [
                                 [
@@ -1315,19 +1311,19 @@
                                     0
                                 ],
                                 [
-                                    5,
-                                    0
-                                ],
-                                [
                                     6,
                                     0
                                 ],
                                 [
-                                    7,
+                                    8,
                                     0
                                 ],
                                 [
-                                    8,
+                                    12,
+                                    0
+                                ],
+                                [
+                                    13,
                                     0
                                 ],
                                 [
@@ -1337,28 +1333,16 @@
                                 [
                                     18,
                                     0
-                                ],
-                                [
-                                    20,
-                                    0
-                                ],
-                                [
-                                    22,
-                                    0
-                                ],
-                                [
-                                    23,
-                                    0
                                 ]
                             ],
                             "interpolate": false
                         }
                     ],
-                    "default_day_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_Sun",
+                    "default_day_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_Sun",
                     "schedule_rules": [
                         {
                             "type": "ScheduleRuleAbridged",
-                            "schedule_day": "OfficeMedium BLDG_LIGHT_SCH_2013_Wkdy",
+                            "schedule_day": "OfficeMedium BLDG_EQUIP_SCH_2013_Wkdy",
                             "apply_sunday": false,
                             "apply_monday": true,
                             "apply_tuesday": true,
@@ -1377,7 +1361,7 @@
                         },
                         {
                             "type": "ScheduleRuleAbridged",
-                            "schedule_day": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                            "schedule_day": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
                             "apply_sunday": false,
                             "apply_monday": false,
                             "apply_tuesday": false,
@@ -1395,9 +1379,9 @@
                             ]
                         }
                     ],
-                    "holiday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
-                    "summer_designday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_SmrDsn",
-                    "winter_designday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_WntrDsn",
+                    "holiday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                    "summer_designday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_WntrDsn",
                     "schedule_type_limit": "Fractional"
                 },
                 {
@@ -1661,15 +1645,15 @@
                 },
                 {
                     "type": "ScheduleRulesetAbridged",
-                    "identifier": "Generic Office Equipment",
+                    "identifier": "Generic Office Lighting",
                     "day_schedules": [
                         {
                             "type": "ScheduleDay",
-                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Sun",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Sun",
                             "values": [
-                                0.2307553806,
-                                0.288107175,
-                                0.2307553806
+                                0.05,
+                                0.04311628,
+                                0.05
                             ],
                             "times": [
                                 [
@@ -1689,7 +1673,7 @@
                         },
                         {
                             "type": "ScheduleDay",
-                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_SmrDsn",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_SmrDsn",
                             "values": [
                                 1.0
                             ],
@@ -1703,7 +1687,7 @@
                         },
                         {
                             "type": "ScheduleDay",
-                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_WntrDsn",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_WntrDsn",
                             "values": [
                                 0.0
                             ],
@@ -1717,14 +1701,14 @@
                         },
                         {
                             "type": "ScheduleDay",
-                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
                             "values": [
-                                0.2307553806,
-                                0.381234796,
-                                0.476543495,
-                                0.3335804465,
-                                0.285926097,
-                                0.2307553806
+                                0.05,
+                                0.08623256,
+                                0.25869768,
+                                0.12934884,
+                                0.04311628,
+                                0.05
                             ],
                             "times": [
                                 [
@@ -1756,15 +1740,18 @@
                         },
                         {
                             "type": "ScheduleDay",
-                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Wkdy",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Wkdy",
                             "values": [
-                                0.3076738408,
-                                0.381234796,
-                                0.857778291,
-                                0.762469592,
-                                0.857778291,
-                                0.476543495,
-                                0.381234796
+                                0.05,
+                                0.1,
+                                0.08623256,
+                                0.25869768,
+                                0.77609304,
+                                0.4311628,
+                                0.25869768,
+                                0.17246512,
+                                0.08623256,
+                                0.04311628
                             ],
                             "times": [
                                 [
@@ -1772,19 +1759,19 @@
                                     0
                                 ],
                                 [
+                                    5,
+                                    0
+                                ],
+                                [
                                     6,
                                     0
                                 ],
                                 [
+                                    7,
+                                    0
+                                ],
+                                [
                                     8,
-                                    0
-                                ],
-                                [
-                                    12,
-                                    0
-                                ],
-                                [
-                                    13,
                                     0
                                 ],
                                 [
@@ -1794,16 +1781,28 @@
                                 [
                                     18,
                                     0
+                                ],
+                                [
+                                    20,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ],
+                                [
+                                    23,
+                                    0
                                 ]
                             ],
                             "interpolate": false
                         }
                     ],
-                    "default_day_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_Sun",
+                    "default_day_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_Sun",
                     "schedule_rules": [
                         {
                             "type": "ScheduleRuleAbridged",
-                            "schedule_day": "OfficeMedium BLDG_EQUIP_SCH_2013_Wkdy",
+                            "schedule_day": "OfficeMedium BLDG_LIGHT_SCH_2013_Wkdy",
                             "apply_sunday": false,
                             "apply_monday": true,
                             "apply_tuesday": true,
@@ -1822,7 +1821,7 @@
                         },
                         {
                             "type": "ScheduleRuleAbridged",
-                            "schedule_day": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                            "schedule_day": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
                             "apply_sunday": false,
                             "apply_monday": false,
                             "apply_tuesday": false,
@@ -1840,20 +1839,22 @@
                             ]
                         }
                     ],
-                    "holiday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
-                    "summer_designday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_SmrDsn",
-                    "winter_designday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_WntrDsn",
+                    "holiday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                    "summer_designday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_WntrDsn",
                     "schedule_type_limit": "Fractional"
                 }
             ],
             "schedule_type_limits": [
                 {
                     "type": "ScheduleTypeLimit",
-                    "identifier": "Fractional",
+                    "identifier": "Activity Level",
                     "lower_limit": 0.0,
-                    "upper_limit": 1.0,
+                    "upper_limit": {
+                        "type": "NoLimit"
+                    },
                     "numeric_type": "Continuous",
-                    "unit_type": "Dimensionless"
+                    "unit_type": "ActivityLevel"
                 },
                 {
                     "type": "ScheduleTypeLimit",
@@ -1867,13 +1868,11 @@
                 },
                 {
                     "type": "ScheduleTypeLimit",
-                    "identifier": "Activity Level",
+                    "identifier": "Fractional",
                     "lower_limit": 0.0,
-                    "upper_limit": {
-                        "type": "NoLimit"
-                    },
+                    "upper_limit": 1.0,
                     "numeric_type": "Continuous",
-                    "unit_type": "ActivityLevel"
+                    "unit_type": "Dimensionless"
                 }
             ]
         }
@@ -2524,6 +2523,5 @@
                 }
             ]
         }
-    ],
-    "north_angle": 15.0
+    ]
 }

--- a/scripts/sample_model.py
+++ b/scripts/sample_model.py
@@ -77,8 +77,6 @@ def model_complete_simple(directory):
 
     model = Model('NewDevelopment', [building], [tree_canopy])
 
-    model.north_angle = 15
-
     dest_file = os.path.join(directory, 'model_complete_simple.json')
     with open(dest_file, 'w') as fp:
         json.dump(model.to_dict(), fp, indent=4)


### PR DESCRIPTION
After some discussions with @mostaphaRoudsari , we have decided that the north should not be a property of the Model for the same reason why we don't have the location as a part of the model. The north direction is a property of the simulation assets like the skies used in Radiance or the simulation parameters used in our EnergyPlus.