### PR TITLE
fix(openapi-spec): make enum reusable

### DIFF
--- a/docs.py
+++ b/docs.py
@@ -1,5 +1,5 @@
 """generate openapi docs."""
-from honeybee_schema._openapi import get_openapi, get_model_mapper
+from honeybee_schema._openapi import get_openapi, class_mapper
 from dragonfly_schema.model import Model
 
 import json
@@ -70,7 +70,5 @@ with open('./docs/model_inheritance.json', 'w') as out_file:
     json.dump(openapi, out_file, indent=2)
 
 # add the mapper file
-mapper = get_model_mapper(Model)
-module_mapper = {k: c.__module__ for k, c in mapper.items()}
 with open('./docs/model_mapper.json', 'w') as out_file:
-    json.dump(module_mapper, out_file, indent=2)
+    json.dump(class_mapper(Model), out_file, indent=2)

--- a/docs/index.html
+++ b/docs/index.html
@@ -62,7 +62,7 @@
 </div>
 <div class="doc-link">
   <a href="./model.html">Model Schema</a><br>
-  <a href="https://ladybug-tools-in2.github.io/honeybee-schema/simulation-parameter.html">Energy Simulation Parameter Schema</a>
+  <a href="https://ladybug-tools.github.io/honeybee-schema/simulation-parameter.html">Energy Simulation Parameter Schema</a>
 </div>
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 
-honeybee-schema==1.28.0
+honeybee-schema==1.28.1
 # pydantic==1.5.1
 git+https://github.com/samuelcolvin/pydantic.git@5067508eca6222b9315b1e38a30ddc975dee05e7


### PR DESCRIPTION
this commit uses the updated methods from honeybee-schema to:

1. reuse the enum objects
2. update the mapper class structure

fixes: #63