### PR TITLE
build(deps): bump honeybee-schema from 1.30.2 to 1.30.3

### DIFF
--- a/docs.py
+++ b/docs.py
@@ -71,4 +71,4 @@ with open('./docs/model_inheritance.json', 'w') as out_file:
 
 # add the mapper file
 with open('./docs/model_mapper.json', 'w') as out_file:
-    json.dump(class_mapper(Model), out_file, indent=2)
+    json.dump(class_mapper([Model]), out_file, indent=2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 
-honeybee-schema==1.30.2
+honeybee-schema==1.30.3
 # pydantic==1.5.1
 git+https://github.com/samuelcolvin/pydantic.git@5067508eca6222b9315b1e38a30ddc975dee05e7


### PR DESCRIPTION
Made a fix in docs.py to pass a list to openapi instead of an item.