### PR TITLE
fix(pydantic): Upgrade Pydantic to 1.6.1 and remove workarounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
     install:
     - pip install -r dev-requirements.txt
     - pip install -r requirements.txt
+    - npm install -g redoc-cli
     script:
     - export CLEAN_TAG=$(echo $TRAVIS_TAG | sed 's/v//g')
     - python docs.py --version $CLEAN_TAG

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-
 honeybee-schema==1.35.1
-# pydantic==1.5.1
-git+https://github.com/samuelcolvin/pydantic.git@5067508eca6222b9315b1e38a30ddc975dee05e7
+pydantic==1.6.1

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,6 @@ with open("README.md", "r") as fh:
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
-dependency_links = []
-for req in requirements:
-    if req.startswith('git+'):
-        dependency_links.append(req)
-        requirements.remove(req)
-
 setuptools.setup(
     name="dragonfly-schema",
     use_scm_version=True,
@@ -24,7 +18,6 @@ setuptools.setup(
     url="https://github.com/ladybug-tools/dragonfly-schema",
     packages=setuptools.find_packages(exclude=["tests", "scripts", "samples"]),
     install_requires=requirements,
-    dependency_links=dependency_links,
     classifiers=[
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
This is a pretty straightforward PR and I plan to just merge it.

I only requested your review @mostaphaRoudsari and @MingboPeng , so that you are aware of the change and the fact that we are officially free of using the pydantic version from github.