### PR TITLE
fix(openapi schema): use pydantic-openapi-helper package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-honeybee-schema==1.39.3
-pydantic==1.7.2
+honeybee-schema==1.39.4


### PR DESCRIPTION
Updated the docs.py to use pydantic-openapi-helper packages. The pydantic-openapi-helper is the new package that we will be using for generating openapi docs.